### PR TITLE
Update repository URLs from ansible-akamai to silexdata.akamai

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the [Releasing guidelines](https://github.com/ansible/community-docs/blob/ma
 
 ## Release notes
 
-See the [changelog](https://github.com/SilexDataTeam/ansible-akamai/blob/main/CHANGELOG.md).
+See the [changelog](https://github.com/SilexDataTeam/silexdata.akamai/blob/main/CHANGELOG.md).
 
 ## More information
 

--- a/changelogs/fragments/issue-2.yml
+++ b/changelogs/fragments/issue-2.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update repository URLs in documentation and collection metadata from ``ansible-akamai`` to ``silexdata.akamai``.

--- a/docs/manage_akamai_module.md
+++ b/docs/manage_akamai_module.md
@@ -18,7 +18,7 @@ Ansible Module for working with Akamai OPEN APIs
 - Or install directly from the source repository:
 
   ```shell
-  ansible-galaxy collection install git+https://github.com/SilexDataTeam/ansible-akamai.git
+  ansible-galaxy collection install git+https://github.com/SilexDataTeam/silexdata.akamai.git
   ```
 
 - Once installed, invoke the module by its fully qualified collection name, `silexdata.akamai.manage_akamai`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -49,7 +49,7 @@ tags:
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/SilexDataTeam/ansible-akamai
+repository: https://github.com/SilexDataTeam/silexdata.akamai
 
 # The URL to any online docs
 documentation: https://galaxy.ansible.com/ui/repo/published/silexdata/akamai/docs/
@@ -58,7 +58,7 @@ documentation: https://galaxy.ansible.com/ui/repo/published/silexdata/akamai/doc
 homepage: https://www.silexdata.com/
 
 # The URL to the collection issue tracker
-issues: https://github.com/SilexDataTeam/ansible-akamai/issues
+issues: https://github.com/SilexDataTeam/silexdata.akamai/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This


### PR DESCRIPTION
## Summary

- Updated `README.md`, `galaxy.yml`, and `docs/manage_akamai_module.md` to replace all `ansible-akamai` GitHub URLs with `silexdata.akamai` following the repository rename.

## Changes

| File | Change |
|------|--------|
| `README.md` | Changelog link URL updated |
| `galaxy.yml` | `repository` and `issues` URLs updated |
| `docs/manage_akamai_module.md` | `ansible-galaxy` install-from-source URL updated |

## Test plan

- [ ] Verify all links in the updated files resolve correctly after the GitHub repo rename goes live
- [ ] `grep -r "ansible-akamai" . --exclude-dir=.git` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)